### PR TITLE
feat: Migrate to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
-features = ["winsock2"]
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.42"
+features = ["Win32_Networking_WinSock"]


### PR DESCRIPTION
`winapi` is now unmaintained. This PR migrates this crate from `winapi` to `windows-sys`.

This is a breaking change.